### PR TITLE
Adição de comando sync-db

### DIFF
--- a/backend/snk_web/README.md
+++ b/backend/snk_web/README.md
@@ -24,11 +24,34 @@ nvm use
 
 ## Desenvolvimento
 
+### Scripts
+
+Os scripts devem ser executados da raiz do projeto Node.JS:
+```bash
+cd snk_web
+```
+
+Scripts disponíveis:
+- `npm run dev`: inicia servidor web
+- `npm run sync-db`: sincroniza entidades no banco de dados de acordo com as Models
+- `npm run prettier`: aplica formatação padrão de estilo no código
+
 ### Servidor web
 
-Execute o comando `npm install` na raiz do projeto para instalar as dependências.
+Entre na pasta raiz:
+```bash
+cd snk_web
+```
 
-Para subir o servidor local execute `npm run dev`.
+[Opcional] Instale as dependências:
+```bash
+npm install
+```
+
+Para subir o servidor local:
+```bash
+npm run dev
+```
 
 O servidor será inicializado na porta padrão `:3000`, e estará disponível em `localhost:3000`.
 
@@ -40,7 +63,7 @@ Entre na raiz do projeto `cd snk_web` e execute o comando `docker-compose up`.\
 
 A sua instância do MySQL deverá subir e os logs aparecerão na sua sessão do terminal.\
 
-Caso queira deixar a instância rodando em background, adicione "&" ao final do comando: `docker-compose up &`.
+Caso queira deixar a instância rodando em background, adicione "&" ao final do comando: `docker-compose up -d`.
 
 Para conferir se a instância subiu, execute `docker ps`, uma instância com nome `backend_db_1` deverá aparecer.
 

--- a/backend/snk_web/bin/sync_db
+++ b/backend/snk_web/bin/sync_db
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+
+// Needs this require to work. WTF?
+const app = require("../app");
+
+const db = require("../lib/database");
+
+db.sync({ force: true, alter: true, match: /db/, logging: false})
+  .then(sequelize => {
+    console.info("Database synced successfully 🎉");
+    process.exit(0);
+  })
+  .catch(err => {
+    console.error("Failed to sync database", { error: err });
+    process.exit(1);
+  })
+

--- a/backend/snk_web/bin/www
+++ b/backend/snk_web/bin/www
@@ -4,14 +4,9 @@
  * Module dependencies.
  */
 
-var debug = require("debug")("snk-web:server");
-var http = require("http");
-var app = require("../app");
-
-if (process.env.DEBUG) {
-  var dotenv = require("dotenv");
-  dotenv.config();
-}
+const debug = require("debug")("snk-web:server");
+const http = require("http");
+const app = require("../app");
 
 // Forçando import da lib de database para validar conexão
 const db = require("../lib/database");

--- a/backend/snk_web/package.json
+++ b/backend/snk_web/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "start": "node ./bin/www",
+    "sync-db": "node ./bin/sync_db",
     "dev": "nodemon ./bin/www",
     "style": "npx prettier --write ."
   },

--- a/backend/snk_web/package.json
+++ b/backend/snk_web/package.json
@@ -6,7 +6,7 @@
     "start": "node ./bin/www",
     "sync-db": "node ./bin/sync_db",
     "dev": "nodemon ./bin/www",
-    "style": "npx prettier --write ."
+    "prettier": "npx prettier --write ."
   },
   "dependencies": {
     "cookie-parser": "^1.4.4",


### PR DESCRIPTION
Adiciona comando para sincronizar o banco de dados sem a necessidade de rodar as migrations: `npm run sync-db`